### PR TITLE
Feature/semi step2

### DIFF
--- a/src/main/java/com/c4cometrue/mystorage/api/FileController.java
+++ b/src/main/java/com/c4cometrue/mystorage/api/FileController.java
@@ -19,6 +19,7 @@ import com.c4cometrue.mystorage.api.dto.FileUploadDto;
 import com.c4cometrue.mystorage.service.FileService;
 
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
 import lombok.RequiredArgsConstructor;
 
 @RestController
@@ -31,7 +32,7 @@ public class FileController {
 	@PostMapping
 	@ResponseStatus(HttpStatus.CREATED)
 	public FileUploadDto.Response upload(
-		@RequestPart MultipartFile file, long userId, long folderId
+		@RequestPart @NotNull MultipartFile file, long userId, long folderId
 	) {
 		return fileService.fileUpload(file, userId, folderId);
 	}

--- a/src/main/java/com/c4cometrue/mystorage/api/FileController.java
+++ b/src/main/java/com/c4cometrue/mystorage/api/FileController.java
@@ -31,9 +31,9 @@ public class FileController {
 	@PostMapping
 	@ResponseStatus(HttpStatus.CREATED)
 	public FileUploadDto.Response upload(
-		@RequestPart MultipartFile file, long userId
+		@RequestPart MultipartFile file, long userId, long folderId
 	) {
-		return fileService.fileUpload(file, userId);
+		return fileService.fileUpload(file, userId, folderId);
 	}
 
 	@GetMapping

--- a/src/main/java/com/c4cometrue/mystorage/api/FileController.java
+++ b/src/main/java/com/c4cometrue/mystorage/api/FileController.java
@@ -20,6 +20,7 @@ import com.c4cometrue.mystorage.service.FileService;
 
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
 import lombok.RequiredArgsConstructor;
 
 @RestController
@@ -32,7 +33,7 @@ public class FileController {
 	@PostMapping
 	@ResponseStatus(HttpStatus.CREATED)
 	public FileUploadDto.Response upload(
-		@RequestPart @NotNull MultipartFile file, long userId, long folderId
+		@RequestPart @NotNull MultipartFile file, @Positive long userId, @Positive long folderId
 	) {
 		return fileService.fileUpload(file, userId, folderId);
 	}

--- a/src/main/java/com/c4cometrue/mystorage/api/FolderController.java
+++ b/src/main/java/com/c4cometrue/mystorage/api/FolderController.java
@@ -1,12 +1,14 @@
 package com.c4cometrue.mystorage.api;
 
 import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.c4cometrue.mystorage.api.dto.FolderRenameDto;
 import com.c4cometrue.mystorage.api.dto.FolderUploadDto;
 import com.c4cometrue.mystorage.service.FolderService;
 
@@ -34,6 +36,14 @@ public class FolderController {
 		@RequestBody @Valid FolderUploadDto.Req req
 	) {
 		return folderService.createFolder(req.userId(), req.parentId(), req.name());
+	}
+
+	@PatchMapping
+	@ResponseStatus(HttpStatus.OK)
+	public void renameFolder(
+		@RequestBody @Valid FolderRenameDto.Req req
+	) {
+		folderService.renameFolder(req.userId(), req.folderId(), req.name());
 	}
 
 }

--- a/src/main/java/com/c4cometrue/mystorage/api/FolderController.java
+++ b/src/main/java/com/c4cometrue/mystorage/api/FolderController.java
@@ -24,14 +24,6 @@ public class FolderController {
 
 	private final FolderService folderService;
 
-	@PostMapping("/root")
-	@ResponseStatus(HttpStatus.CREATED)
-	public FolderUploadDto.Res createRootFolder(
-		@RequestBody @Valid FolderUploadDto.Req req
-	) {
-		return folderService.createRootFolder(req.userId(), req.name());
-	}
-
 	@PostMapping
 	@ResponseStatus(HttpStatus.CREATED)
 	public FolderUploadDto.Res createFolder(

--- a/src/main/java/com/c4cometrue/mystorage/api/FolderController.java
+++ b/src/main/java/com/c4cometrue/mystorage/api/FolderController.java
@@ -1,0 +1,39 @@
+package com.c4cometrue.mystorage.api;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.c4cometrue.mystorage.api.dto.FolderUploadDto;
+import com.c4cometrue.mystorage.service.FolderService;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/v1/folders")
+public class FolderController {
+
+	private final FolderService folderService;
+
+	@PostMapping("/root")
+	@ResponseStatus(HttpStatus.CREATED)
+	public FolderUploadDto.Res createRootFolder(
+		@RequestBody @Valid FolderUploadDto.Req req
+	) {
+		return folderService.createRootFolder(req.userId(), req.name());
+	}
+
+	@PostMapping
+	@ResponseStatus(HttpStatus.CREATED)
+	public FolderUploadDto.Res createFolder(
+		@RequestBody @Valid FolderUploadDto.Req req
+	) {
+		return folderService.createFolder(req.userId(), req.parentId(), req.name());
+	}
+
+}

--- a/src/main/java/com/c4cometrue/mystorage/api/FolderController.java
+++ b/src/main/java/com/c4cometrue/mystorage/api/FolderController.java
@@ -1,6 +1,7 @@
 package com.c4cometrue.mystorage.api;
 
 import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -8,6 +9,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.c4cometrue.mystorage.api.dto.FolderGetDto;
 import com.c4cometrue.mystorage.api.dto.FolderRenameDto;
 import com.c4cometrue.mystorage.api.dto.FolderUploadDto;
 import com.c4cometrue.mystorage.service.FolderService;
@@ -44,6 +46,14 @@ public class FolderController {
 		@RequestBody @Valid FolderRenameDto.Req req
 	) {
 		folderService.renameFolder(req.userId(), req.folderId(), req.name());
+	}
+
+	@GetMapping
+	@ResponseStatus(HttpStatus.OK)
+	public FolderGetDto.Res getFolderContents(
+		@RequestBody @Valid FolderGetDto.Req req
+	) {
+		return folderService.getFolderContents(req.userId(), req.folderId());
 	}
 
 }

--- a/src/main/java/com/c4cometrue/mystorage/api/RegisterController.java
+++ b/src/main/java/com/c4cometrue/mystorage/api/RegisterController.java
@@ -1,0 +1,31 @@
+package com.c4cometrue.mystorage.api;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.c4cometrue.mystorage.api.dto.FolderUploadDto;
+import com.c4cometrue.mystorage.service.FolderService;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/v1/register")
+public class RegisterController {
+
+	private final FolderService folderService;
+
+	@PostMapping("/root-folder")
+	@ResponseStatus(HttpStatus.CREATED)
+	public FolderUploadDto.Res createRootFolder(
+		@RequestBody @Valid FolderUploadDto.Req req
+	) {
+		return folderService.createRootFolder(req.userId(), req.name());
+	}
+
+}

--- a/src/main/java/com/c4cometrue/mystorage/api/dto/FileDeleteDto.java
+++ b/src/main/java/com/c4cometrue/mystorage/api/dto/FileDeleteDto.java
@@ -1,12 +1,13 @@
 package com.c4cometrue.mystorage.api.dto;
 
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
 
 public class FileDeleteDto {
 
 	public record Request(
-		@NotNull(message = "유저 ID는 null이 될 수 없습니다.") Long userId,
-		@NotNull(message = "파일 ID는 null이 될 수 없습니다.") Long fileId
+		@NotNull(message = "유저 ID는 null이 될 수 없습니다.") @Positive Long userId,
+		@NotNull(message = "파일 ID는 null이 될 수 없습니다.") @Positive Long fileId
 	) {
 
 	}

--- a/src/main/java/com/c4cometrue/mystorage/api/dto/FileDownloadDto.java
+++ b/src/main/java/com/c4cometrue/mystorage/api/dto/FileDownloadDto.java
@@ -3,12 +3,13 @@ package com.c4cometrue.mystorage.api.dto;
 import java.util.Arrays;
 
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
 
 public class FileDownloadDto {
 
 	public record Request(
-		@NotNull(message = "유저 ID는 null이 될 수 없습니다.") Long userId,
-		@NotNull(message = "파일 ID는 null이 될 수 없습니다.") Long fileId
+		@NotNull(message = "유저 ID는 null이 될 수 없습니다.") @Positive Long userId,
+		@NotNull(message = "파일 ID는 null이 될 수 없습니다.") @Positive Long fileId
 	) {
 
 	}

--- a/src/main/java/com/c4cometrue/mystorage/api/dto/FolderGetDto.java
+++ b/src/main/java/com/c4cometrue/mystorage/api/dto/FolderGetDto.java
@@ -24,9 +24,9 @@ public class FolderGetDto {
 	}
 
 	public record FileDto(
-		long folderId,
+		long fileId,
 		FileType fileType,
-		String folderName,
+		String fileName,
 		String createdAt,
 		long fileSize
 	) {

--- a/src/main/java/com/c4cometrue/mystorage/api/dto/FolderGetDto.java
+++ b/src/main/java/com/c4cometrue/mystorage/api/dto/FolderGetDto.java
@@ -7,12 +7,13 @@ import com.c4cometrue.mystorage.domain.FileMetaData;
 import com.c4cometrue.mystorage.domain.FileType;
 
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
 
 public class FolderGetDto {
 
 	public record Req(
-		@NotNull(message = "유저 ID는 Null이 될 수 없습니다.") Long userId,
-		@NotNull(message = "폴더 ID는 Null이 될 수 없습니다.") Long folderId
+		@NotNull(message = "유저 ID는 Null이 될 수 없습니다.") @Positive Long userId,
+		@NotNull(message = "폴더 ID는 Null이 될 수 없습니다.") @Positive Long folderId
 	) {
 	}
 

--- a/src/main/java/com/c4cometrue/mystorage/api/dto/FolderGetDto.java
+++ b/src/main/java/com/c4cometrue/mystorage/api/dto/FolderGetDto.java
@@ -1,0 +1,44 @@
+package com.c4cometrue.mystorage.api.dto;
+
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+
+import com.c4cometrue.mystorage.domain.FileMetaData;
+import com.c4cometrue.mystorage.domain.FileType;
+
+import jakarta.validation.constraints.NotNull;
+
+public class FolderGetDto {
+
+	public record Req(
+		@NotNull(message = "유저 ID는 Null이 될 수 없습니다.") Long userId,
+		@NotNull(message = "폴더 ID는 Null이 될 수 없습니다.") Long folderId
+	) {
+	}
+
+	public record Res(
+		Long folderId,
+		String folderName,
+		List<FileDto> subFileList
+	) {
+	}
+
+	public record FileDto(
+		long folderId,
+		FileType fileType,
+		String folderName,
+		String createdAt,
+		long fileSize
+	) {
+		public static FileDto from(FileMetaData data) {
+			return new FileDto(
+				data.getId(),
+				data.getFileType(),
+				data.getFileName(),
+				DateTimeFormatter.ISO_LOCAL_DATE_TIME.format(data.getCreatedAt()),
+				data.getSize()
+			);
+		}
+	}
+
+}

--- a/src/main/java/com/c4cometrue/mystorage/api/dto/FolderRenameDto.java
+++ b/src/main/java/com/c4cometrue/mystorage/api/dto/FolderRenameDto.java
@@ -6,10 +6,9 @@ import jakarta.validation.constraints.NotNull;
 public class FolderRenameDto {
 
 	public record Req(
-		long userId,
+		@NotNull(message = "유저 ID는 Null이 될 수 없습니다.") Long userId,
 		@NotNull(message = "폴더 ID는 Null이 될 수 없습니다.") Long folderId,
 		@NotBlank(message = "폴더 이름은 빈 문자열이 될 수 없습니다.") String name
 	) {
-
 	}
 }

--- a/src/main/java/com/c4cometrue/mystorage/api/dto/FolderRenameDto.java
+++ b/src/main/java/com/c4cometrue/mystorage/api/dto/FolderRenameDto.java
@@ -2,12 +2,13 @@ package com.c4cometrue.mystorage.api.dto;
 
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
 
 public class FolderRenameDto {
 
 	public record Req(
-		@NotNull(message = "유저 ID는 Null이 될 수 없습니다.") Long userId,
-		@NotNull(message = "폴더 ID는 Null이 될 수 없습니다.") Long folderId,
+		@NotNull(message = "유저 ID는 Null이 될 수 없습니다.") @Positive Long userId,
+		@NotNull(message = "폴더 ID는 Null이 될 수 없습니다.") @Positive Long folderId,
 		@NotBlank(message = "폴더 이름은 빈 문자열이 될 수 없습니다.") String name
 	) {
 	}

--- a/src/main/java/com/c4cometrue/mystorage/api/dto/FolderRenameDto.java
+++ b/src/main/java/com/c4cometrue/mystorage/api/dto/FolderRenameDto.java
@@ -1,0 +1,15 @@
+package com.c4cometrue.mystorage.api.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+public class FolderRenameDto {
+
+	public record Req(
+		long userId,
+		@NotNull(message = "폴더 ID는 Null이 될 수 없습니다.") Long folderId,
+		@NotBlank(message = "폴더 이름은 빈 문자열이 될 수 없습니다.") String name
+	) {
+
+	}
+}

--- a/src/main/java/com/c4cometrue/mystorage/api/dto/FolderUploadDto.java
+++ b/src/main/java/com/c4cometrue/mystorage/api/dto/FolderUploadDto.java
@@ -2,12 +2,13 @@ package com.c4cometrue.mystorage.api.dto;
 
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
 
 public class FolderUploadDto {
 
 	public record Req(
-		Long parentId,
-		@NotNull(message = "유저 ID는 Null이 될 수 없습니다.") Long userId,
+		@Positive Long parentId,
+		@NotNull(message = "유저 ID는 Null이 될 수 없습니다.") @Positive Long userId,
 		@NotBlank(message = "폴더 이름은 빈 문자열이 될 수 없습니다.") String name
 	) {
 	}

--- a/src/main/java/com/c4cometrue/mystorage/api/dto/FolderUploadDto.java
+++ b/src/main/java/com/c4cometrue/mystorage/api/dto/FolderUploadDto.java
@@ -1,0 +1,18 @@
+package com.c4cometrue.mystorage.api.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+public class FolderUploadDto {
+
+	public record Req(
+		long userId,
+		long parentId,
+		@NotBlank(message = "폴더 이름은 빈 문자열이 될 수 없습니다.") String name
+	) {
+	}
+
+	public record Res(
+		Long id
+	) {
+	}
+}

--- a/src/main/java/com/c4cometrue/mystorage/api/dto/FolderUploadDto.java
+++ b/src/main/java/com/c4cometrue/mystorage/api/dto/FolderUploadDto.java
@@ -1,12 +1,13 @@
 package com.c4cometrue.mystorage.api.dto;
 
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 
 public class FolderUploadDto {
 
 	public record Req(
-		long userId,
-		long parentId,
+		@NotNull(message = "유저 ID는 Null이 될 수 없습니다.") Long userId,
+		@NotNull(message = "부모 폴더 ID는 Null이 될 수 없습니다.") Long parentId,
 		@NotBlank(message = "폴더 이름은 빈 문자열이 될 수 없습니다.") String name
 	) {
 	}

--- a/src/main/java/com/c4cometrue/mystorage/api/dto/FolderUploadDto.java
+++ b/src/main/java/com/c4cometrue/mystorage/api/dto/FolderUploadDto.java
@@ -6,8 +6,8 @@ import jakarta.validation.constraints.NotNull;
 public class FolderUploadDto {
 
 	public record Req(
+		Long parentId,
 		@NotNull(message = "유저 ID는 Null이 될 수 없습니다.") Long userId,
-		@NotNull(message = "부모 폴더 ID는 Null이 될 수 없습니다.") Long parentId,
 		@NotBlank(message = "폴더 이름은 빈 문자열이 될 수 없습니다.") String name
 	) {
 	}

--- a/src/main/java/com/c4cometrue/mystorage/common/exception/ErrorCode.java
+++ b/src/main/java/com/c4cometrue/mystorage/common/exception/ErrorCode.java
@@ -13,6 +13,7 @@ public enum ErrorCode {
 	INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 오류입니다."),
 	BAD_REQUEST_ERROR(HttpStatus.BAD_REQUEST, "잘못된 요청입니다."),
 	FILE_NOT_FOUND(HttpStatus.NOT_FOUND, "파일이 존재하지 않습니다."),
+	FOLDER_NOT_FOUND(HttpStatus.NOT_FOUND, "폴더가 존재하지 않습니다."),
 
 	// file-upload
 	FILE_EMPTY(HttpStatus.BAD_REQUEST, "업로드할 파일이 없습니다."),
@@ -29,7 +30,7 @@ public enum ErrorCode {
 	// folder-create
 	FOLDER_CREATE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "폴더 생성에 실패했습니다."),
 	DUPLICATE_FOLDER(HttpStatus.BAD_REQUEST, "이미 존재하는 이름의 폴더입니다."),
-	INVALID_FOLDER(HttpStatus.BAD_REQUEST, "유효하지 않은 폴더입니다.");
+	INVALID_FOLDER(HttpStatus.BAD_REQUEST, "폴더 형식이 아닙니다.");
 
 	private final HttpStatus httpStatus;
 

--- a/src/main/java/com/c4cometrue/mystorage/common/exception/ErrorCode.java
+++ b/src/main/java/com/c4cometrue/mystorage/common/exception/ErrorCode.java
@@ -24,7 +24,12 @@ public enum ErrorCode {
 	FILE_DOWNLOAD_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "파일 다운로드에 실패했습니다."),
 
 	// file-delete
-	FILE_DELETE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "파일 삭제에 실패했습니다.");
+	FILE_DELETE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "파일 삭제에 실패했습니다."),
+
+	// folder-create
+	FOLDER_CREATE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "폴더 생성에 실패했습니다."),
+	DUPLICATE_FOLDER(HttpStatus.BAD_REQUEST, "이미 존재하는 이름의 폴더입니다."),
+	INVALID_FOLDER(HttpStatus.BAD_REQUEST, "유효하지 않은 폴더입니다.");
 
 	private final HttpStatus httpStatus;
 

--- a/src/main/java/com/c4cometrue/mystorage/common/exception/ErrorCode.java
+++ b/src/main/java/com/c4cometrue/mystorage/common/exception/ErrorCode.java
@@ -30,7 +30,7 @@ public enum ErrorCode {
 	// folder-create
 	FOLDER_CREATE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "폴더 생성에 실패했습니다."),
 	DUPLICATE_FOLDER(HttpStatus.BAD_REQUEST, "이미 존재하는 이름의 폴더입니다."),
-	INVALID_FOLDER(HttpStatus.BAD_REQUEST, "폴더 형식이 아닙니다.");
+	INVALID_TYPE(HttpStatus.BAD_REQUEST, "잘못된 폴더/파일 형식입니다.");
 
 	private final HttpStatus httpStatus;
 

--- a/src/main/java/com/c4cometrue/mystorage/domain/FileMetaData.java
+++ b/src/main/java/com/c4cometrue/mystorage/domain/FileMetaData.java
@@ -1,8 +1,5 @@
 package com.c4cometrue.mystorage.domain;
 
-import java.util.List;
-
-import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -13,7 +10,6 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
-import jakarta.persistence.OneToMany;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -30,10 +26,10 @@ public class FileMetaData extends BaseEntity {
 
 	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "parent_id")
-	private FileMetaData parent;
+	private FileMetaData parent = null;
 
-	@OneToMany(mappedBy = "parent", cascade = CascadeType.REMOVE) // 읽기 전용 메서드
-	private List<FileMetaData> childList;
+	// @OneToMany(mappedBy = "parent", cascade = CascadeType.REMOVE) // 읽기 전용 메서드
+	// private List<FileMetaData> childList;
 
 	@Column(nullable = false)
 	private Long userId;
@@ -51,41 +47,38 @@ public class FileMetaData extends BaseEntity {
 	@Column(nullable = false)
 	private FileType fileType;
 
-	private String folderPath;
-
 	@Builder(builderMethodName = "fileBuilder")
-	public FileMetaData(Long userId, String fileName, String uploadName, long size, String type, String folderPath,
-		FileType fileType) {
+	public FileMetaData(
+		Long userId, String fileName, String uploadName, long size, String type, FileType fileType,
+		FileMetaData parent
+	) {
 		this.userId = userId;
 		this.fileName = fileName;
 		this.uploadName = uploadName;
 		this.size = size;
 		this.type = type;
-		this.folderPath = folderPath;
 		this.fileType = fileType;
+		this.parent = parent;
 	}
 
 	@Builder(builderMethodName = "folderBuilder")
-	public FileMetaData(Long userId, String fileName, String uploadName, String folderPath, FileType fileType) {
+	public FileMetaData(Long userId, String fileName, String uploadName, FileType fileType,
+		FileMetaData parent) {
 		this.userId = userId;
 		this.fileName = fileName;
 		this.uploadName = uploadName;
-		this.folderPath = folderPath;
 		this.fileType = fileType;
+		this.parent = parent;
 	}
 
-	public void addParentFolder(FileMetaData fileMetaData) {
-		this.parent = fileMetaData;
-		if (parent != null) {
-			parent.childList.add(this);
-		}
-	}
+	// public void addParentFolder(FileMetaData fileMetaData) {
+	// 	this.parent = fileMetaData;
+	// 	if (parent != null) {
+	// 		parent.childList.add(this);
+	// 	}
+	// }
 
 	public void rename(String newName) {
 		this.fileName = newName;
-	}
-
-	public void updateFolderPath(String newFolderPath) {
-		this.folderPath = newFolderPath;
 	}
 }

--- a/src/main/java/com/c4cometrue/mystorage/domain/FileMetaData.java
+++ b/src/main/java/com/c4cometrue/mystorage/domain/FileMetaData.java
@@ -29,9 +29,6 @@ public class FileMetaData extends BaseEntity {
 	@JoinColumn(name = "parent_id")
 	private FileMetaData parent;
 
-	// @OneToMany(mappedBy = "parent", cascade = CascadeType.REMOVE) // 읽기 전용 메서드
-	// private List<FileMetaData> childList;
-
 	@Column(nullable = false)
 	private Long userId;
 
@@ -73,13 +70,6 @@ public class FileMetaData extends BaseEntity {
 		this.fileType = fileType;
 		this.parent = parent;
 	}
-
-	// public void addParentFolder(FileMetaData fileMetaData) {
-	// 	this.parent = fileMetaData;
-	// 	if (parent != null) {
-	// 		parent.childList.add(this);
-	// 	}
-	// }
 
 	public void rename(String newName) {
 		this.fileName = newName;

--- a/src/main/java/com/c4cometrue/mystorage/domain/FileMetaData.java
+++ b/src/main/java/com/c4cometrue/mystorage/domain/FileMetaData.java
@@ -1,10 +1,19 @@
 package com.c4cometrue.mystorage.domain;
 
+import java.util.List;
+
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -19,27 +28,64 @@ public class FileMetaData extends BaseEntity {
 	@Column(name = "file_meta_data_id")
 	private Long id;
 
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "parent_id")
+	private FileMetaData parent;
+
+	@OneToMany(mappedBy = "parent", cascade = CascadeType.REMOVE) // 읽기 전용 메서드
+	private List<FileMetaData> childList;
+
 	@Column(nullable = false)
 	private Long userId;
 
 	@Column(nullable = false)
 	private String fileName;
 
-	@Column(nullable = false)
 	private String uploadName;
 
-	@Column(nullable = false)
 	private long size;
 
-	@Column(nullable = false)
 	private String type;
 
-	@Builder
-	public FileMetaData(Long userId, String fileName, String uploadName, long size, String type) {
+	@Enumerated(EnumType.STRING)
+	@Column(nullable = false)
+	private FileType fileType;
+
+	private String folderPath;
+
+	@Builder(builderMethodName = "fileBuilder")
+	public FileMetaData(Long userId, String fileName, String uploadName, long size, String type, String folderPath,
+		FileType fileType) {
 		this.userId = userId;
 		this.fileName = fileName;
 		this.uploadName = uploadName;
 		this.size = size;
 		this.type = type;
+		this.folderPath = folderPath;
+		this.fileType = fileType;
+	}
+
+	@Builder(builderMethodName = "folderBuilder")
+	public FileMetaData(Long userId, String fileName, String uploadName, String folderPath, FileType fileType) {
+		this.userId = userId;
+		this.fileName = fileName;
+		this.uploadName = uploadName;
+		this.folderPath = folderPath;
+		this.fileType = fileType;
+	}
+
+	public void addParentFolder(FileMetaData fileMetaData) {
+		this.parent = fileMetaData;
+		if (parent != null) {
+			parent.childList.add(this);
+		}
+	}
+
+	public void rename(String newName) {
+		this.fileName = newName;
+	}
+
+	public void updateFolderPath(String newFolderPath) {
+		this.folderPath = newFolderPath;
 	}
 }

--- a/src/main/java/com/c4cometrue/mystorage/domain/FileMetaData.java
+++ b/src/main/java/com/c4cometrue/mystorage/domain/FileMetaData.java
@@ -10,13 +10,14 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
 @Getter
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class FileMetaData extends BaseEntity {
 
 	@Id
@@ -47,8 +48,20 @@ public class FileMetaData extends BaseEntity {
 	@Column(nullable = false)
 	private FileType fileType;
 
+	@Builder(builderMethodName = "rootBuilder")
+	public FileMetaData(
+		Long id, Long userId, String fileName, String uploadName, FileType fileType
+	) {
+		this.id = id;
+		this.userId = userId;
+		this.fileName = fileName;
+		this.uploadName = uploadName;
+		this.fileType = fileType;
+	}
+
 	@Builder(builderMethodName = "fileBuilder")
 	public FileMetaData(
+
 		Long userId, String fileName, String uploadName, long size, String type, FileType fileType,
 		FileMetaData parent
 	) {
@@ -57,16 +70,6 @@ public class FileMetaData extends BaseEntity {
 		this.uploadName = uploadName;
 		this.size = size;
 		this.type = type;
-		this.fileType = fileType;
-		this.parent = parent;
-	}
-
-	@Builder(builderMethodName = "folderBuilder")
-	public FileMetaData(Long userId, String fileName, String uploadName, FileType fileType,
-		FileMetaData parent) {
-		this.userId = userId;
-		this.fileName = fileName;
-		this.uploadName = uploadName;
 		this.fileType = fileType;
 		this.parent = parent;
 	}

--- a/src/main/java/com/c4cometrue/mystorage/domain/FileMetaData.java
+++ b/src/main/java/com/c4cometrue/mystorage/domain/FileMetaData.java
@@ -26,7 +26,7 @@ public class FileMetaData extends BaseEntity {
 
 	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "parent_id")
-	private FileMetaData parent = null;
+	private FileMetaData parent;
 
 	// @OneToMany(mappedBy = "parent", cascade = CascadeType.REMOVE) // 읽기 전용 메서드
 	// private List<FileMetaData> childList;
@@ -39,7 +39,7 @@ public class FileMetaData extends BaseEntity {
 
 	private String uploadName;
 
-	private long size;
+	private long size = 0;
 
 	private String type;
 

--- a/src/main/java/com/c4cometrue/mystorage/domain/FileType.java
+++ b/src/main/java/com/c4cometrue/mystorage/domain/FileType.java
@@ -1,0 +1,5 @@
+package com.c4cometrue.mystorage.domain;
+
+public enum FileType {
+	FOLDER, FILE
+}

--- a/src/main/java/com/c4cometrue/mystorage/repository/FileMetaDataReader.java
+++ b/src/main/java/com/c4cometrue/mystorage/repository/FileMetaDataReader.java
@@ -1,5 +1,7 @@
 package com.c4cometrue.mystorage.repository;
 
+import java.util.List;
+
 import org.springframework.stereotype.Component;
 
 import com.c4cometrue.mystorage.common.exception.BusinessException;
@@ -34,6 +36,10 @@ public class FileMetaDataReader {
 		if (repository.existsByFileNameAndUserIdAndParent(folderName, userId, parent)) {
 			throw new BusinessException(ErrorCode.DUPLICATE_FOLDER);
 		}
+	}
+
+	public List<FileMetaData> getFiles(long userId, FileMetaData parent) {
+		return repository.findAllByUserIdAndParent(userId, parent);
 	}
 
 }

--- a/src/main/java/com/c4cometrue/mystorage/repository/FileMetaDataReader.java
+++ b/src/main/java/com/c4cometrue/mystorage/repository/FileMetaDataReader.java
@@ -2,7 +2,7 @@ package com.c4cometrue.mystorage.repository;
 
 import java.util.List;
 
-import org.springframework.stereotype.Component;
+import org.springframework.stereotype.Repository;
 
 import com.c4cometrue.mystorage.common.exception.BusinessException;
 import com.c4cometrue.mystorage.common.exception.ErrorCode;
@@ -10,7 +10,7 @@ import com.c4cometrue.mystorage.domain.FileMetaData;
 
 import lombok.RequiredArgsConstructor;
 
-@Component
+@Repository
 @RequiredArgsConstructor
 public class FileMetaDataReader {
 

--- a/src/main/java/com/c4cometrue/mystorage/repository/FileMetaDataReader.java
+++ b/src/main/java/com/c4cometrue/mystorage/repository/FileMetaDataReader.java
@@ -1,0 +1,29 @@
+package com.c4cometrue.mystorage.repository;
+
+import org.springframework.stereotype.Component;
+
+import com.c4cometrue.mystorage.common.exception.BusinessException;
+import com.c4cometrue.mystorage.common.exception.ErrorCode;
+import com.c4cometrue.mystorage.domain.FileMetaData;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class FileMetaDataReader {
+
+	private final FileMetaDataRepository repository;
+
+	public FileMetaData get(long id, long userId) {
+		return repository.findByIdAndUserId(id, userId).orElseThrow(
+			() -> new BusinessException(ErrorCode.FILE_NOT_FOUND));
+	}
+
+	public boolean isDuplicateFile(String fileName, long userId) {
+		return repository.existsByFileNameAndUserId(fileName, userId);
+	}
+
+	public boolean isDuplicateFolderName(FileMetaData folder, String name) {
+		return repository.existsByParentAndFileName(folder, name);
+	}
+}

--- a/src/main/java/com/c4cometrue/mystorage/repository/FileMetaDataReader.java
+++ b/src/main/java/com/c4cometrue/mystorage/repository/FileMetaDataReader.java
@@ -19,11 +19,21 @@ public class FileMetaDataReader {
 			() -> new BusinessException(ErrorCode.FILE_NOT_FOUND));
 	}
 
-	public boolean isDuplicateFile(String fileName, long userId) {
-		return repository.existsByFileNameAndUserId(fileName, userId);
+	public FileMetaData getRootFolder(long userId) {
+		return repository.findByUserIdAndParent(userId, null).orElseThrow(
+			() -> new BusinessException(ErrorCode.FILE_NOT_FOUND));
 	}
 
-	public boolean isDuplicateFolderName(FileMetaData folder, String name) {
-		return repository.existsByParentAndFileName(folder, name);
+	public void validateDuplicateFile(String fileName, long userId, FileMetaData parent) {
+		if (repository.existsByFileNameAndUserIdAndParent(fileName, userId, parent)) {
+			throw new BusinessException(ErrorCode.DUPLICATE_FILE);
+		}
 	}
+
+	public void validateDuplicateFolder(String folderName, long userId, FileMetaData parent) {
+		if (repository.existsByFileNameAndUserIdAndParent(folderName, userId, parent)) {
+			throw new BusinessException(ErrorCode.DUPLICATE_FOLDER);
+		}
+	}
+
 }

--- a/src/main/java/com/c4cometrue/mystorage/repository/FileMetaDataReader.java
+++ b/src/main/java/com/c4cometrue/mystorage/repository/FileMetaDataReader.java
@@ -23,19 +23,11 @@ public class FileMetaDataReader {
 
 	public FileMetaData getRootFolder(long userId) {
 		return repository.findByUserIdAndParent(userId, null).orElseThrow(
-			() -> new BusinessException(ErrorCode.FILE_NOT_FOUND));
+			() -> new BusinessException(ErrorCode.FOLDER_NOT_FOUND));
 	}
 
-	public void validateDuplicateFile(String fileName, long userId, FileMetaData parent) {
-		if (repository.existsByFileNameAndUserIdAndParent(fileName, userId, parent)) {
-			throw new BusinessException(ErrorCode.DUPLICATE_FILE);
-		}
-	}
-
-	public void validateDuplicateFolder(String folderName, long userId, FileMetaData parent) {
-		if (repository.existsByFileNameAndUserIdAndParent(folderName, userId, parent)) {
-			throw new BusinessException(ErrorCode.DUPLICATE_FOLDER);
-		}
+	public boolean isDuplicateFile(String fileName, long userId, FileMetaData parent) {
+		return repository.existsByFileNameAndUserIdAndParent(fileName, userId, parent);
 	}
 
 	public List<FileMetaData> getFiles(long userId, FileMetaData parent) {

--- a/src/main/java/com/c4cometrue/mystorage/repository/FileMetaDataRepository.java
+++ b/src/main/java/com/c4cometrue/mystorage/repository/FileMetaDataRepository.java
@@ -8,10 +8,10 @@ import com.c4cometrue.mystorage.domain.FileMetaData;
 
 public interface FileMetaDataRepository extends JpaRepository<FileMetaData, Long> {
 
-	boolean existsByFileNameAndUserId(String fileName, long userId);
-
-	boolean existsByParentAndFileName(FileMetaData parent, String name);
+	boolean existsByFileNameAndUserIdAndParent(String fileName, long userId, FileMetaData parent);
 
 	Optional<FileMetaData> findByIdAndUserId(long fileId, long userId);
+
+	Optional<FileMetaData> findByUserIdAndParent(long userId, FileMetaData parent);
 
 }

--- a/src/main/java/com/c4cometrue/mystorage/repository/FileMetaDataRepository.java
+++ b/src/main/java/com/c4cometrue/mystorage/repository/FileMetaDataRepository.java
@@ -1,11 +1,17 @@
 package com.c4cometrue.mystorage.repository;
 
+import java.util.Optional;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.c4cometrue.mystorage.domain.FileMetaData;
 
 public interface FileMetaDataRepository extends JpaRepository<FileMetaData, Long> {
 
-    boolean existsByFileNameAndUserId(String fileName, long userId);
+	boolean existsByFileNameAndUserId(String fileName, long userId);
+
+	boolean existsByParentAndFileName(FileMetaData parent, String name);
+
+	Optional<FileMetaData> findByIdAndUserId(long fileId, long userId);
 
 }

--- a/src/main/java/com/c4cometrue/mystorage/repository/FileMetaDataRepository.java
+++ b/src/main/java/com/c4cometrue/mystorage/repository/FileMetaDataRepository.java
@@ -1,5 +1,6 @@
 package com.c4cometrue.mystorage.repository;
 
+import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -13,5 +14,7 @@ public interface FileMetaDataRepository extends JpaRepository<FileMetaData, Long
 	Optional<FileMetaData> findByIdAndUserId(long fileId, long userId);
 
 	Optional<FileMetaData> findByUserIdAndParent(long userId, FileMetaData parent);
+
+	List<FileMetaData> findAllByUserIdAndParent(long userId, FileMetaData parent);
 
 }

--- a/src/main/java/com/c4cometrue/mystorage/repository/FileMetaDataWriter.java
+++ b/src/main/java/com/c4cometrue/mystorage/repository/FileMetaDataWriter.java
@@ -1,6 +1,7 @@
 package com.c4cometrue.mystorage.repository;
 
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
 import com.c4cometrue.mystorage.domain.FileMetaData;
@@ -10,6 +11,7 @@ import lombok.RequiredArgsConstructor;
 
 @Component
 @RequiredArgsConstructor
+@Transactional
 public class FileMetaDataWriter {
 
 	private final FileMetaDataRepository repository;
@@ -33,7 +35,7 @@ public class FileMetaDataWriter {
 	public FileMetaData saveFolderMetaData(
 		long userId, String folderName, FileMetaData parent
 	) {
-		FileMetaData folderMetaData = FileMetaData.folderBuilder()
+		FileMetaData folderMetaData = FileMetaData.fileBuilder()
 			.userId(userId)
 			.fileName(folderName)
 			.uploadName(".")

--- a/src/main/java/com/c4cometrue/mystorage/repository/FileMetaDataWriter.java
+++ b/src/main/java/com/c4cometrue/mystorage/repository/FileMetaDataWriter.java
@@ -1,0 +1,51 @@
+package com.c4cometrue.mystorage.repository;
+
+import org.springframework.stereotype.Component;
+import org.springframework.web.multipart.MultipartFile;
+
+import com.c4cometrue.mystorage.domain.FileMetaData;
+import com.c4cometrue.mystorage.domain.FileType;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class FileMetaDataWriter {
+
+	private final FileMetaDataRepository repository;
+
+	public FileMetaData saveFileMetaData(
+		MultipartFile file, long userId, String uploadFileName, String folderPath
+	) {
+		FileMetaData fileMetaData = FileMetaData.fileBuilder()
+			.userId(userId)
+			.fileName(file.getOriginalFilename())
+			.uploadName(uploadFileName)
+			.size(file.getSize())
+			.type(file.getContentType())
+			.folderPath(folderPath)
+			.fileType(FileType.FILE)
+			.build();
+
+		return repository.save(fileMetaData);
+	}
+
+	public FileMetaData saveFolderMetaData(
+		long userId, String folderName, String folderPath, FileMetaData parent
+	) {
+		FileMetaData folderMetaData = FileMetaData.folderBuilder()
+			.userId(userId)
+			.fileName(folderName)
+			.folderPath(folderPath)
+			.uploadName(".")
+			.fileType(FileType.FOLDER)
+			.build();
+
+		folderMetaData.addParentFolder(parent);
+		return repository.save(folderMetaData);
+	}
+
+	public void delete(FileMetaData fileMetaData) {
+		repository.delete(fileMetaData);
+	}
+}

--- a/src/main/java/com/c4cometrue/mystorage/repository/FileMetaDataWriter.java
+++ b/src/main/java/com/c4cometrue/mystorage/repository/FileMetaDataWriter.java
@@ -1,6 +1,6 @@
 package com.c4cometrue.mystorage.repository;
 
-import org.springframework.stereotype.Component;
+import org.springframework.stereotype.Repository;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -9,7 +9,7 @@ import com.c4cometrue.mystorage.domain.FileType;
 
 import lombok.RequiredArgsConstructor;
 
-@Component
+@Repository
 @RequiredArgsConstructor
 @Transactional
 public class FileMetaDataWriter {

--- a/src/main/java/com/c4cometrue/mystorage/repository/FileMetaDataWriter.java
+++ b/src/main/java/com/c4cometrue/mystorage/repository/FileMetaDataWriter.java
@@ -15,7 +15,7 @@ public class FileMetaDataWriter {
 	private final FileMetaDataRepository repository;
 
 	public FileMetaData saveFileMetaData(
-		MultipartFile file, long userId, String uploadFileName, String folderPath
+		MultipartFile file, long userId, String uploadFileName, FileMetaData parent
 	) {
 		FileMetaData fileMetaData = FileMetaData.fileBuilder()
 			.userId(userId)
@@ -23,7 +23,7 @@ public class FileMetaDataWriter {
 			.uploadName(uploadFileName)
 			.size(file.getSize())
 			.type(file.getContentType())
-			.folderPath(folderPath)
+			.parent(parent)
 			.fileType(FileType.FILE)
 			.build();
 
@@ -31,17 +31,16 @@ public class FileMetaDataWriter {
 	}
 
 	public FileMetaData saveFolderMetaData(
-		long userId, String folderName, String folderPath, FileMetaData parent
+		long userId, String folderName, FileMetaData parent
 	) {
 		FileMetaData folderMetaData = FileMetaData.folderBuilder()
 			.userId(userId)
 			.fileName(folderName)
-			.folderPath(folderPath)
 			.uploadName(".")
 			.fileType(FileType.FOLDER)
+			.parent(parent)
 			.build();
 
-		folderMetaData.addParentFolder(parent);
 		return repository.save(folderMetaData);
 	}
 

--- a/src/main/java/com/c4cometrue/mystorage/service/FileService.java
+++ b/src/main/java/com/c4cometrue/mystorage/service/FileService.java
@@ -93,4 +93,5 @@ public class FileService {
 			throw new BusinessException(ErrorCode.INVALID_FILE_ACCESS);
 		}
 	}
+
 }

--- a/src/main/java/com/c4cometrue/mystorage/service/FileService.java
+++ b/src/main/java/com/c4cometrue/mystorage/service/FileService.java
@@ -38,7 +38,7 @@ public class FileService {
 
 		// 이미 같은 폴더 아래에 파일이 존재하는지 확인
 		String originName = file.getOriginalFilename();
-		fileMetaDataReader.validateDuplicateFile(originName, userId, parentFolder);
+		validateDuplicateFile(originName, userId, parentFolder);
 
 		// 파일 메타데이터 저장
 		String uploadFileName = pathService.createUniqueFileName(originName);
@@ -94,4 +94,9 @@ public class FileService {
 		}
 	}
 
+	public void validateDuplicateFile(String fileName, long userId, FileMetaData parent) {
+		if (fileMetaDataReader.isDuplicateFile(fileName, userId, parent)) {
+			throw new BusinessException(ErrorCode.DUPLICATE_FILE);
+		}
+	}
 }

--- a/src/main/java/com/c4cometrue/mystorage/service/FolderService.java
+++ b/src/main/java/com/c4cometrue/mystorage/service/FolderService.java
@@ -1,0 +1,68 @@
+package com.c4cometrue.mystorage.service;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.c4cometrue.mystorage.api.dto.FolderUploadDto;
+import com.c4cometrue.mystorage.common.exception.BusinessException;
+import com.c4cometrue.mystorage.common.exception.ErrorCode;
+import com.c4cometrue.mystorage.domain.FileMetaData;
+import com.c4cometrue.mystorage.domain.FileType;
+import com.c4cometrue.mystorage.repository.FileMetaDataReader;
+import com.c4cometrue.mystorage.repository.FileMetaDataWriter;
+import com.c4cometrue.mystorage.utils.FileUtil;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class FolderService {
+	private final PathService pathService;
+	private final FileUtil fileUtil;
+	private final FileMetaDataReader folderReader;
+	private final FileMetaDataWriter folderWriter;
+
+	private static final String ROOT_PATH = "";
+
+	public FolderUploadDto.Res createRootFolder(long userId, String name) {
+		String fullPath = pathService.getFullFilePath(ROOT_PATH, name);
+
+		// 이미 폴더가 존재하는지 확인
+		validateDuplicateFolderName(null, name);
+
+		// 메타데이터 저장
+		FileMetaData folder = folderWriter.saveFolderMetaData(userId, name, ROOT_PATH, null);
+
+		// 물리적인 루트 폴더 생성
+		fileUtil.createFolder(fullPath);
+		return new FolderUploadDto.Res(folder.getId());
+	}
+
+	public FolderUploadDto.Res createFolder(long userId, Long parentId, String name) {
+		// 부모 폴더 유효성 검사
+		FileMetaData parent = getParentFolder(parentId, userId);
+
+		// 중복되는 이름이 같은 뎁스에 있는 경우 확인
+		validateDuplicateFolderName(parent, name);
+
+		// 메타 데이터만 저장
+		String folderPath = pathService.getFilePath(parent.getFolderPath(), parent.getFileName());
+		FileMetaData folder = folderWriter.saveFolderMetaData(userId, name, folderPath, parent);
+		return new FolderUploadDto.Res(folder.getId());
+	}
+
+	private FileMetaData getParentFolder(Long id, long userId) {
+		FileMetaData folder = this.folderReader.get(id, userId);
+		if (folder.getFileType() != FileType.FOLDER) {
+			throw new BusinessException(ErrorCode.INVALID_FOLDER);
+		}
+		return folder;
+	}
+
+	private void validateDuplicateFolderName(FileMetaData folder, String name) {
+		if (this.folderReader.isDuplicateFolderName(folder, name)) {
+			throw new BusinessException(ErrorCode.DUPLICATE_FOLDER);
+		}
+	}
+}

--- a/src/main/java/com/c4cometrue/mystorage/service/FolderService.java
+++ b/src/main/java/com/c4cometrue/mystorage/service/FolderService.java
@@ -18,7 +18,6 @@ import com.c4cometrue.mystorage.utils.FileUtil;
 import lombok.RequiredArgsConstructor;
 
 @Service
-@Transactional
 @RequiredArgsConstructor
 public class FolderService {
 	private final PathService pathService;
@@ -28,6 +27,7 @@ public class FolderService {
 
 	private static final String ROOT_PATH = "";
 
+	@Transactional
 	public FolderUploadDto.Res createRootFolder(long userId, String name) {
 		String fullPath = pathService.getFullFilePath(ROOT_PATH, name);
 
@@ -42,6 +42,7 @@ public class FolderService {
 		return new FolderUploadDto.Res(folder.getId());
 	}
 
+	@Transactional
 	public FolderUploadDto.Res createFolder(long userId, long parentId, String name) {
 		// 부모 폴더 유효성 검사
 		FileMetaData parent = getFolder(parentId, userId);
@@ -54,6 +55,7 @@ public class FolderService {
 		return new FolderUploadDto.Res(folder.getId());
 	}
 
+	@Transactional
 	public void renameFolder(long userId, long folderId, String newName) {
 		// 폴더 존재 여부 확인
 		FileMetaData folder = getFolder(folderId, userId);
@@ -65,6 +67,7 @@ public class FolderService {
 		folder.rename(newName);
 	}
 
+	// 페이징 필요
 	@Transactional(readOnly = true)
 	public FolderGetDto.Res getFolderContents(long userId, long folderId) {
 		// 폴더 존재 여부 확인
@@ -82,12 +85,12 @@ public class FolderService {
 	private FileMetaData getFolder(long id, long userId) {
 		FileMetaData folder = folderReader.get(id, userId);
 		if (folder.getFileType() != FileType.FOLDER) {
-			throw new BusinessException(ErrorCode.INVALID_FOLDER);
+			throw new BusinessException(ErrorCode.INVALID_TYPE);
 		}
 		return folder;
 	}
 
-	public void validateDuplicateFolder(String folderName, long userId, FileMetaData parent) {
+	private void validateDuplicateFolder(String folderName, long userId, FileMetaData parent) {
 		if (folderReader.isDuplicateFile(folderName, userId, parent)) {
 			throw new BusinessException(ErrorCode.DUPLICATE_FOLDER);
 		}

--- a/src/main/java/com/c4cometrue/mystorage/service/FolderService.java
+++ b/src/main/java/com/c4cometrue/mystorage/service/FolderService.java
@@ -32,7 +32,7 @@ public class FolderService {
 		String fullPath = pathService.getFullFilePath(ROOT_PATH, name);
 
 		// 이미 폴더가 존재하는지 확인
-		folderReader.validateDuplicateFolder(name, userId, null);
+		validateDuplicateFolder(name, userId, null);
 
 		// 메타데이터 저장
 		FileMetaData folder = folderWriter.saveFolderMetaData(userId, name, null);
@@ -47,7 +47,7 @@ public class FolderService {
 		FileMetaData parent = getFolder(parentId, userId);
 
 		// 중복되는 이름이 같은 뎁스에 있는 경우 확인
-		folderReader.validateDuplicateFolder(name, userId, parent);
+		validateDuplicateFolder(name, userId, parent);
 
 		// 메타 데이터만 저장
 		FileMetaData folder = folderWriter.saveFolderMetaData(userId, name, parent);
@@ -59,7 +59,7 @@ public class FolderService {
 		FileMetaData folder = getFolder(folderId, userId);
 
 		// 변경하려는 이름이 중복되는지 확인
-		folderReader.validateDuplicateFolder(newName, userId, folder.getParent());
+		validateDuplicateFolder(newName, userId, folder.getParent());
 
 		// 자식들 제외하고 변경하려는 폴더 자체만 이름 수정
 		folder.rename(newName);
@@ -85,5 +85,11 @@ public class FolderService {
 			throw new BusinessException(ErrorCode.INVALID_FOLDER);
 		}
 		return folder;
+	}
+
+	public void validateDuplicateFolder(String folderName, long userId, FileMetaData parent) {
+		if (folderReader.isDuplicateFile(folderName, userId, parent)) {
+			throw new BusinessException(ErrorCode.DUPLICATE_FOLDER);
+		}
 	}
 }

--- a/src/main/java/com/c4cometrue/mystorage/service/PathService.java
+++ b/src/main/java/com/c4cometrue/mystorage/service/PathService.java
@@ -1,10 +1,13 @@
 package com.c4cometrue.mystorage.service;
 
-import java.util.Objects;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
 import java.util.UUID;
 
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
 
 @Service
 public class PathService {
@@ -14,8 +17,9 @@ public class PathService {
 	@Value("${file.upload-dir}")
 	private String baseDir;
 
-	public String createUniqueFileName(String originFileName) {
-		return UUID.randomUUID() + originFileName;
+	public String createUniqueFileName() {
+		LocalDateTime now = LocalDateTime.now(ZoneId.of("Asia/Seoul"));
+		return now.format(DateTimeFormatter.ofPattern("yyyyMMdd_HHmmss")) + UUID.randomUUID();
 	}
 
 	/**
@@ -25,8 +29,8 @@ public class PathService {
 	 * @return
 	 */
 	public String getFullFilePath(String parentDir, String fileName) {
-		String validatedFileName = fileName.trim();
-		if (Objects.equals(parentDir, "")) {
+		String validatedFileName = fileName.stripTrailing();
+		if (!StringUtils.hasLength(parentDir)) {
 			return baseDir + validatedFileName;
 		}
 		return baseDir + parentDir + DELIMITER + validatedFileName;

--- a/src/main/java/com/c4cometrue/mystorage/service/PathService.java
+++ b/src/main/java/com/c4cometrue/mystorage/service/PathService.java
@@ -19,16 +19,6 @@ public class PathService {
 	}
 
 	/**
-	 * 파일의 논리적인 경로 반환
-	 * @param parentDir
-	 * @param parentName
-	 * @return
-	 */
-	public String getFilePath(String parentDir, String parentName) {
-		return parentDir + DELIMITER + parentName;
-	}
-
-	/**
 	 * 파일의 물리적인 경로 반환
 	 * @param parentDir
 	 * @param fileName

--- a/src/main/java/com/c4cometrue/mystorage/service/PathService.java
+++ b/src/main/java/com/c4cometrue/mystorage/service/PathService.java
@@ -1,0 +1,45 @@
+package com.c4cometrue.mystorage.service;
+
+import java.util.Objects;
+import java.util.UUID;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+@Service
+public class PathService {
+
+	private static final String DELIMITER = "/";
+
+	@Value("${file.upload-dir}")
+	private String baseDir;
+
+	public String createUniqueFileName(String originFileName) {
+		return UUID.randomUUID() + originFileName;
+	}
+
+	/**
+	 * 파일의 논리적인 경로 반환
+	 * @param parentDir
+	 * @param parentName
+	 * @return
+	 */
+	public String getFilePath(String parentDir, String parentName) {
+		return parentDir + DELIMITER + parentName;
+	}
+
+	/**
+	 * 파일의 물리적인 경로 반환
+	 * @param parentDir
+	 * @param fileName
+	 * @return
+	 */
+	public String getFullFilePath(String parentDir, String fileName) {
+		String validatedFileName = fileName.trim();
+		if (Objects.equals(parentDir, "")) {
+			return baseDir + validatedFileName;
+		}
+		return baseDir + parentDir + DELIMITER + validatedFileName;
+	}
+
+}

--- a/src/main/java/com/c4cometrue/mystorage/utils/FileUtil.java
+++ b/src/main/java/com/c4cometrue/mystorage/utils/FileUtil.java
@@ -1,6 +1,7 @@
 package com.c4cometrue.mystorage.utils;
 
 import java.io.IOException;
+import java.nio.file.FileAlreadyExistsException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 
@@ -53,6 +54,18 @@ public class FileUtil {
 			Files.delete(destinationPath);
 		} catch (IOException ex) {
 			throw new BusinessException(ErrorCode.FILE_DELETE_FAILED, ex);
+		}
+	}
+
+	public void createFolder(String folderPath) {
+		Path destinationPath = Path.of(folderPath).normalize();
+
+		try {
+			Files.createDirectory(destinationPath);
+		} catch (FileAlreadyExistsException ex) {
+			throw new BusinessException(ErrorCode.DUPLICATE_FOLDER, ex);
+		} catch (IOException ex) {
+			throw new BusinessException(ErrorCode.FOLDER_CREATE_FAILED, ex);
 		}
 	}
 

--- a/src/main/java/com/c4cometrue/mystorage/utils/FileUtil.java
+++ b/src/main/java/com/c4cometrue/mystorage/utils/FileUtil.java
@@ -64,7 +64,7 @@ public class FileUtil {
 			Files.createDirectory(destinationPath);
 		} catch (FileAlreadyExistsException ex) {
 			throw new BusinessException(ErrorCode.DUPLICATE_FOLDER, ex);
-		} catch (IOException ex) {
+		} catch (Exception ex) {
 			throw new BusinessException(ErrorCode.FOLDER_CREATE_FAILED, ex);
 		}
 	}

--- a/src/test/java/com/c4cometrue/mystorage/api/FileControllerTest.java
+++ b/src/test/java/com/c4cometrue/mystorage/api/FileControllerTest.java
@@ -50,7 +50,7 @@ class FileControllerTest {
 		var content = "hello";
 
 		var response = new FileUploadDto.Response(fileId, userId, uploadFileName, fileSize);
-		given(fileService.fileUpload(any(), anyLong())).willReturn(response);
+		given(fileService.fileUpload(any(), anyLong(), anyLong())).willReturn(response);
 
 		// when + then
 		mockMvc.perform(

--- a/src/test/java/com/c4cometrue/mystorage/api/FileControllerTest.java
+++ b/src/test/java/com/c4cometrue/mystorage/api/FileControllerTest.java
@@ -57,6 +57,7 @@ class FileControllerTest {
 				multipart("/v1/files")
 					.file("file", content.getBytes())
 					.param("userId", "1")
+					.param("folderId", "1")
 			)
 			.andExpectAll(
 				status().isCreated(),

--- a/src/test/java/com/c4cometrue/mystorage/api/FolderControllerTest.java
+++ b/src/test/java/com/c4cometrue/mystorage/api/FolderControllerTest.java
@@ -36,29 +36,6 @@ class FolderControllerTest {
 	ObjectMapper mapper = new ObjectMapper();
 
 	@Test
-	void 루트_폴더를_생성한다() throws Exception {
-		// given
-		var userId = 1L;
-		var folderId = 1L;
-		var name = "name";
-
-		var response = new FolderUploadDto.Res(folderId);
-		var request = new FolderUploadDto.Req(null, userId, name);
-		given(folderService.createRootFolder(anyLong(), anyString())).willReturn(response);
-
-		// when + then
-		mockMvc.perform(
-				post("/v1/folders/root")
-					.contentType(MediaType.APPLICATION_JSON)
-					.content(mapper.writeValueAsString(request))
-			)
-			.andExpectAll(
-				status().isCreated(),
-				jsonPath("$.id").value(folderId)
-			);
-	}
-
-	@Test
 	void 폴더를_생성한다() throws Exception {
 		// given
 		var userId = 1L;
@@ -137,7 +114,6 @@ class FolderControllerTest {
 				jsonPath("$.subFileList[0].fileName").value(fileName),
 				jsonPath("$.subFileList[0].fileType").value(FileType.FILE.name())
 			);
-
 	}
 
 }

--- a/src/test/java/com/c4cometrue/mystorage/api/FolderControllerTest.java
+++ b/src/test/java/com/c4cometrue/mystorage/api/FolderControllerTest.java
@@ -1,0 +1,143 @@
+package com.c4cometrue.mystorage.api;
+
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.anyString;
+import static org.mockito.BDDMockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import com.c4cometrue.mystorage.api.dto.FolderGetDto;
+import com.c4cometrue.mystorage.api.dto.FolderRenameDto;
+import com.c4cometrue.mystorage.api.dto.FolderUploadDto;
+import com.c4cometrue.mystorage.domain.FileType;
+import com.c4cometrue.mystorage.service.FolderService;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+@WebMvcTest(FolderController.class)
+class FolderControllerTest {
+
+	@Autowired
+	MockMvc mockMvc;
+
+	@MockBean
+	FolderService folderService;
+
+	ObjectMapper mapper = new ObjectMapper();
+
+	@Test
+	void 루트_폴더를_생성한다() throws Exception {
+		// given
+		var userId = 1L;
+		var folderId = 1L;
+		var name = "name";
+
+		var response = new FolderUploadDto.Res(folderId);
+		var request = new FolderUploadDto.Req(null, userId, name);
+		given(folderService.createRootFolder(anyLong(), anyString())).willReturn(response);
+
+		// when + then
+		mockMvc.perform(
+				post("/v1/folders/root")
+					.contentType(MediaType.APPLICATION_JSON)
+					.content(mapper.writeValueAsString(request))
+			)
+			.andExpectAll(
+				status().isCreated(),
+				jsonPath("$.id").value(folderId)
+			);
+	}
+
+	@Test
+	void 폴더를_생성한다() throws Exception {
+		// given
+		var userId = 1L;
+		var parentId = 1L;
+		var folderId = 2L;
+		var name = "name";
+
+		var response = new FolderUploadDto.Res(folderId);
+		var request = new FolderUploadDto.Req(parentId, userId, name);
+		given(folderService.createFolder(anyLong(), anyLong(), anyString())).willReturn(response);
+
+		// when + then
+		mockMvc.perform(
+				post("/v1/folders")
+					.contentType(MediaType.APPLICATION_JSON)
+					.content(mapper.writeValueAsString(request))
+			)
+			.andExpectAll(
+				status().isCreated(),
+				jsonPath("$.id").value(folderId)
+			);
+	}
+
+	@Test
+	void 폴더_이름을_변경한다() throws Exception {
+		// given
+		var userId = 1L;
+		var folderId = 2L;
+		var name = "name1";
+
+		var request = new FolderRenameDto.Req(userId, folderId, name);
+
+		// when + then
+		mockMvc.perform(
+				patch("/v1/folders")
+					.contentType(MediaType.APPLICATION_JSON)
+					.content(mapper.writeValueAsString(request))
+			)
+			.andExpectAll(
+				status().isOk()
+			);
+	}
+
+	@Test
+	void 폴더_내용을_반환한다() throws Exception {
+		// given
+		var userId = 1L;
+		var folderId = 2L;
+		var folderName = "folder";
+		var fileId = 3L;
+		var fileName = "file";
+		var createdAt = DateTimeFormatter.ISO_LOCAL_DATE_TIME.format(LocalDateTime.now());
+
+		var response = new FolderGetDto.Res(folderId, folderName,
+			List.of(
+				new FolderGetDto.FileDto(
+					fileId, FileType.FILE, fileName, createdAt, 1000
+				)
+			)
+		);
+
+		var request = new FolderGetDto.Req(userId, folderId);
+		given(folderService.getFolderContents(anyLong(), anyLong())).willReturn(response);
+
+		// when + then
+		mockMvc.perform(
+				get("/v1/folders")
+					.contentType(MediaType.APPLICATION_JSON)
+					.content(mapper.writeValueAsString(request))
+			)
+			.andExpectAll(
+				status().isOk(),
+				jsonPath("$.folderId").value(folderId),
+				jsonPath("$.folderName").value(folderName),
+				jsonPath("$.subFileList[0].fileId").value(fileId),
+				jsonPath("$.subFileList[0].fileName").value(fileName),
+				jsonPath("$.subFileList[0].fileType").value(FileType.FILE.name())
+			);
+
+	}
+
+}

--- a/src/test/java/com/c4cometrue/mystorage/api/RegisterControllerTest.java
+++ b/src/test/java/com/c4cometrue/mystorage/api/RegisterControllerTest.java
@@ -1,0 +1,53 @@
+package com.c4cometrue.mystorage.api;
+
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import com.c4cometrue.mystorage.api.dto.FolderUploadDto;
+import com.c4cometrue.mystorage.service.FolderService;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+@WebMvcTest(RegisterController.class)
+class RegisterControllerTest {
+
+	@Autowired
+	MockMvc mockMvc;
+
+	@MockBean
+	FolderService folderService;
+
+	ObjectMapper mapper = new ObjectMapper();
+
+	@Test
+	void 루트_폴더를_생성한다() throws Exception {
+		// given
+		var userId = 1L;
+		var folderId = 1L;
+		var name = "name";
+
+		var response = new FolderUploadDto.Res(folderId);
+		var request = new FolderUploadDto.Req(null, userId, name);
+		given(folderService.createRootFolder(anyLong(), anyString())).willReturn(response);
+
+		// when + then
+		mockMvc.perform(
+				post("/v1/register/root-folder")
+					.contentType(MediaType.APPLICATION_JSON)
+					.content(mapper.writeValueAsString(request))
+			)
+			.andExpectAll(
+				status().isCreated(),
+				jsonPath("$.id").value(folderId)
+			);
+	}
+
+}

--- a/src/test/java/com/c4cometrue/mystorage/repository/FileMetaDataReaderTest.java
+++ b/src/test/java/com/c4cometrue/mystorage/repository/FileMetaDataReaderTest.java
@@ -1,0 +1,148 @@
+package com.c4cometrue.mystorage.repository;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.util.Objects;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import com.c4cometrue.mystorage.common.exception.BusinessException;
+import com.c4cometrue.mystorage.common.exception.ErrorCode;
+import com.c4cometrue.mystorage.domain.FileMetaData;
+import com.c4cometrue.mystorage.domain.FileType;
+
+@SpringBootTest
+class FileMetaDataReaderTest {
+
+	@Autowired
+	FileMetaDataRepository repository;
+
+	@Autowired
+	FileMetaDataReader fileMetaDataReader;
+
+	@Test
+	void 저장된_파일이_아니라면_조회에_실패한다() {
+		// given
+		var fileId = 1L;
+		var userId = 1L;
+		repository.deleteAll();
+
+		// when + then
+		assertThatThrownBy(() -> {
+			fileMetaDataReader.get(fileId, userId);
+		}).isInstanceOf(BusinessException.class)
+			.hasMessageContaining(ErrorCode.FILE_NOT_FOUND.getMsg());
+	}
+
+	@Test
+	void 저장된_파일을_조회한다() {
+		// given
+		var userId = 1L;
+		var fileName = "name";
+		var fileMetaData = FileMetaData.fileBuilder()
+			.userId(userId)
+			.fileName(fileName)
+			.fileType(FileType.FILE)
+			.build();
+
+		var fileEntity = repository.save(fileMetaData);
+
+		// when
+		var response = fileMetaDataReader.get(fileEntity.getId(), userId);
+
+		// then
+		assertThat(response)
+			.matches(file -> file.getUserId() == userId)
+			.matches(file -> Objects.equals(file.getFileName(), fileName));
+	}
+
+	@Test
+	void 저장된_루트_폴더가_아니라면_조회에_실패한다() {
+		// given
+		var userId = 1L;
+
+		// when + then
+		assertThatThrownBy(() -> {
+			fileMetaDataReader.getRootFolder(userId);
+		}).isInstanceOf(BusinessException.class)
+			.hasMessageContaining(ErrorCode.FOLDER_NOT_FOUND.getMsg());
+	}
+
+	@Test
+	void 루트_폴더를_조회한다() {
+		// given
+		var userId = 1L;
+		var fileName = "name";
+		var folderMetaData = FileMetaData.fileBuilder()
+			.userId(userId)
+			.fileName(fileName)
+			.parent(null)
+			.fileType(FileType.FOLDER)
+			.build();
+
+		var rootFolder = repository.save(folderMetaData);
+
+		// when
+		var response = fileMetaDataReader.getRootFolder(userId);
+
+		// then
+		assertThat(response)
+			.matches(folder -> Objects.equals(folder.getId(), rootFolder.getId()))
+			.matches(folder -> folder.getUserId() == userId)
+			.matches(folder -> Objects.equals(folder.getFileName(), fileName));
+	}
+
+	@Test
+	void 중복된_파일을_감지한다() {
+		// given
+		var userId = 1L;
+		var fileName = "name";
+		var parentFolder = FileMetaData.fileBuilder()
+			.userId(userId)
+			.fileName(fileName)
+			.fileType(FileType.FOLDER)
+			.build();
+
+		var parentEntity = repository.save(parentFolder);
+		var fileMetaData = new FileMetaData(userId, fileName, fileName,
+			100L, "type", FileType.FILE, parentEntity);
+
+		repository.save(fileMetaData);
+
+		// when
+		var response = fileMetaDataReader.isDuplicateFile(fileName, userId, parentEntity);
+
+		// then
+		assertThat(response).isTrue();
+	}
+
+	@Test
+	void 폴더_내부에_존재하는_파일을_반환한다() {
+		// given
+		var userId = 1L;
+		var fileName = "name";
+		var parentFolder = FileMetaData.fileBuilder()
+			.userId(userId)
+			.fileName(fileName)
+			.fileType(FileType.FOLDER)
+			.build();
+
+		var parentEntity = repository.save(parentFolder);
+		var fileMetaData = new FileMetaData(userId, fileName, fileName,
+			100L, "type", FileType.FILE, parentEntity);
+
+		repository.save(fileMetaData);
+
+		// when
+		var response = fileMetaDataReader.getFiles(userId, parentEntity);
+
+		// then
+		assertThat(response)
+			.matches(files -> files.get(0).getUserId() == userId)
+			.matches(files -> Objects.equals(files.get(0).getFileName(), fileName))
+			.matches(files -> Objects.equals(files.get(0).getFileType(), FileType.FILE));
+	}
+
+}

--- a/src/test/java/com/c4cometrue/mystorage/repository/FileMetaDataWriterTest.java
+++ b/src/test/java/com/c4cometrue/mystorage/repository/FileMetaDataWriterTest.java
@@ -1,0 +1,64 @@
+package com.c4cometrue.mystorage.repository;
+
+import static org.mockito.BDDMockito.*;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.web.multipart.MultipartFile;
+
+import com.c4cometrue.mystorage.domain.FileMetaData;
+
+@ExtendWith(MockitoExtension.class)
+class FileMetaDataWriterTest {
+
+	@Mock
+	FileMetaDataRepository repository;
+
+	@InjectMocks
+	FileMetaDataWriter fileMetaDataWriter;
+
+	@Test
+	void 파일_메타데이터를_저장한다() {
+		// given
+		var multipartFile = mock(MultipartFile.class);
+		var userId = 1L;
+		var fileName = "name";
+		var parent = mock(FileMetaData.class);
+
+		// when
+		var response = fileMetaDataWriter.saveFileMetaData(multipartFile, userId, fileName, parent);
+
+		// then
+		verify(repository, times(1)).save(any());
+	}
+
+	@Test
+	void 폴더_메타데이터를_저장한다() {
+		// given
+		var userId = 1L;
+		var fileName = "name";
+		var parent = mock(FileMetaData.class);
+
+		// when
+		var response = fileMetaDataWriter.saveFolderMetaData(userId, fileName, parent);
+
+		// then
+		verify(repository, times(1)).save(any());
+	}
+
+	@Test
+	void 파일_메타데이터를_삭제한다() {
+		// given
+		var fileMetaData = mock(FileMetaData.class);
+
+		// when
+		fileMetaDataWriter.delete(fileMetaData);
+
+		// then
+		verify(repository, times(1)).delete(any());
+	}
+
+}

--- a/src/test/java/com/c4cometrue/mystorage/service/FileServiceTest.java
+++ b/src/test/java/com/c4cometrue/mystorage/service/FileServiceTest.java
@@ -110,7 +110,7 @@ class FileServiceTest {
 		given(fileMetaDataReader.getRootFolder(anyLong())).willReturn(rootFolder);
 		given(fileMetaDataWriter.saveFileMetaData(any(), anyLong(), anyString(), any())).willReturn(fileMetaData);
 		given(fileMetaDataReader.isDuplicateFile(anyString(), anyLong(), any())).willReturn(false);
-		given(pathService.createUniqueFileName(anyString())).willReturn(uploadFileName);
+		given(pathService.createUniqueFileName()).willReturn(uploadFileName);
 		given(pathService.getFullFilePath(anyString(), anyString())).willReturn("C://");
 
 		// when
@@ -132,6 +132,7 @@ class FileServiceTest {
 		var fileMetaData = mock(FileMetaData.class);
 
 		given(fileMetaData.getUserId()).willReturn(1L);
+		given(fileMetaData.getFileType()).willReturn(FileType.FILE);
 		given(fileMetaDataReader.get(anyLong(), anyLong())).willReturn(fileMetaData);
 
 		// when + then
@@ -152,6 +153,7 @@ class FileServiceTest {
 
 		given(fileMetaData.getUserId()).willReturn(userId);
 		given(fileMetaData.getUploadName()).willReturn(fileName);
+		given(fileMetaData.getFileType()).willReturn(FileType.FILE);
 
 		given(fileMetaDataReader.get(anyLong(), anyLong())).willReturn(fileMetaData);
 		given(fileMetaDataReader.getRootFolder(anyLong())).willReturn(rootFolder);
@@ -180,6 +182,7 @@ class FileServiceTest {
 		given(fileMetaData.getUploadName()).willReturn(fileName);
 		given(fileMetaData.getType()).willReturn(contentType);
 		given(fileMetaData.getUserId()).willReturn(userId);
+		given(fileMetaData.getFileType()).willReturn(FileType.FILE);
 
 		given(fileMetaDataReader.get(anyLong(), anyLong())).willReturn(fileMetaData);
 		given(fileMetaDataReader.getRootFolder(anyLong())).willReturn(rootFolder);
@@ -208,6 +211,7 @@ class FileServiceTest {
 		var fileMetaData = mock(FileMetaData.class);
 
 		given(fileMetaData.getUserId()).willReturn(1L);
+		given(fileMetaData.getFileType()).willReturn(FileType.FILE);
 		given(fileMetaDataReader.get(anyLong(), anyLong())).willReturn(fileMetaData);
 
 		// when + then
@@ -227,6 +231,7 @@ class FileServiceTest {
 
 		given(fileMetaData.getUserId()).willReturn(userId);
 		given(fileMetaData.getUploadName()).willReturn(uploadName);
+		given(fileMetaData.getFileType()).willReturn(FileType.FILE);
 		given(fileMetaDataReader.get(anyLong(), anyLong())).willReturn(fileMetaData);
 
 		// when

--- a/src/test/java/com/c4cometrue/mystorage/service/FileServiceTest.java
+++ b/src/test/java/com/c4cometrue/mystorage/service/FileServiceTest.java
@@ -112,7 +112,7 @@ class FileServiceTest {
 		// given
 		var userId = 2L;
 		var fileId = 1L;
-		var fileMetaData = FileMetaData.builder()
+		var fileMetaData = FileMetaData.fileBuilder()
 			.userId(1L)
 			.fileName("name.jpg")
 			.uploadName("name.jp")
@@ -135,7 +135,7 @@ class FileServiceTest {
 		var userId = 1L;
 		var fileId = 1L;
 		var resource = mock(UrlResource.class);
-		var fileMetaData = FileMetaData.builder()
+		var fileMetaData = FileMetaData.fileBuilder()
 			.userId(1L)
 			.fileName("name.jpg")
 			.uploadName("name.jp")
@@ -162,7 +162,7 @@ class FileServiceTest {
 		var fileId = 1L;
 		var contentType = MediaType.IMAGE_JPEG.getType();
 		var fileName = "name.jpg";
-		var fileMetaData = FileMetaData.builder()
+		var fileMetaData = FileMetaData.fileBuilder()
 			.userId(userId)
 			.fileName(fileName)
 			.uploadName(fileName)
@@ -203,7 +203,7 @@ class FileServiceTest {
 		// given
 		var userId = 2L;
 		var fileId = 1L;
-		var fileMetaData = FileMetaData.builder()
+		var fileMetaData = FileMetaData.fileBuilder()
 			.userId(1L)
 			.fileName("name.jpg")
 			.uploadName("name.jp")
@@ -225,7 +225,7 @@ class FileServiceTest {
 		// given
 		var userId = 1L;
 		var fileId = 1L;
-		var fileMetaData = FileMetaData.builder()
+		var fileMetaData = FileMetaData.fileBuilder()
 			.userId(userId)
 			.fileName("name.jpg")
 			.uploadName("name.jp")

--- a/src/test/java/com/c4cometrue/mystorage/service/FileServiceTest.java
+++ b/src/test/java/com/c4cometrue/mystorage/service/FileServiceTest.java
@@ -39,11 +39,12 @@ class FileServiceTest {
 	@Test
 	void 파일이_없다면_실패한다() {
 		//given
-		long userId = 1;
+		var userId = 1L;
+		var folderId = 1L;
 
 		// when + then
 		assertThatThrownBy(() -> {
-			fileService.fileUpload(null, userId);
+			fileService.fileUpload(null, userId, folderId);
 		}).isInstanceOf(BusinessException.class)
 			.hasMessageContaining(ErrorCode.FILE_EMPTY.getMsg());
 	}
@@ -52,15 +53,16 @@ class FileServiceTest {
 	void 중복된_파일이라면_실패한다() {
 		// given
 		var userId = 1L;
+		var folderId = 1L;
 		var file = mock(MultipartFile.class);
 
 		given(file.getOriginalFilename()).willReturn("dd.jpg");
-		given(fileMetaDataRepository.existsByFileNameAndUserId(anyString(), anyLong()))
+		given(fileMetaDataRepository.existsByFileNameAndUserIdAndParent(anyString(), anyLong(), any()))
 			.willReturn(true);
 
 		// when + then
 		assertThatThrownBy(() -> {
-			fileService.fileUpload(file, userId);
+			fileService.fileUpload(file, userId, folderId);
 		}).isInstanceOf(BusinessException.class)
 			.hasMessageContaining(ErrorCode.DUPLICATE_FILE.getMsg());
 	}
@@ -69,6 +71,7 @@ class FileServiceTest {
 	void 파일_메타데이터를_등록한다() {
 		// given
 		var fileId = 1L;
+		var folderId = 2L;
 		var userId = 1L;
 		var file = mock(MultipartFile.class);
 		var originFileName = "dd.jpg";
@@ -87,7 +90,7 @@ class FileServiceTest {
 		given(fileMetaDataRepository.save(any())).willReturn(fileMetaData);
 
 		// when
-		var response = fileService.fileUpload(file, userId);
+		var response = fileService.fileUpload(file, userId, folderId);
 
 		// then
 		assertThat(response)

--- a/src/test/java/com/c4cometrue/mystorage/service/FileServiceTest.java
+++ b/src/test/java/com/c4cometrue/mystorage/service/FileServiceTest.java
@@ -6,9 +6,9 @@ import static org.mockito.BDDMockito.*;
 
 import java.io.IOException;
 import java.util.Arrays;
-import java.util.Optional;
 
 import org.apache.commons.lang3.StringUtils;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -21,30 +21,52 @@ import org.springframework.web.multipart.MultipartFile;
 import com.c4cometrue.mystorage.common.exception.BusinessException;
 import com.c4cometrue.mystorage.common.exception.ErrorCode;
 import com.c4cometrue.mystorage.domain.FileMetaData;
-import com.c4cometrue.mystorage.repository.FileMetaDataRepository;
+import com.c4cometrue.mystorage.domain.FileType;
+import com.c4cometrue.mystorage.repository.FileMetaDataReader;
+import com.c4cometrue.mystorage.repository.FileMetaDataWriter;
 import com.c4cometrue.mystorage.utils.FileUtil;
 
 @ExtendWith(MockitoExtension.class)
 class FileServiceTest {
 
 	@Mock
-	FileMetaDataRepository fileMetaDataRepository;
+	PathService pathService;
 
 	@Mock
 	FileUtil fileUtil;
 
+	@Mock
+	FileMetaDataReader fileMetaDataReader;
+
+	@Mock
+	FileMetaDataWriter fileMetaDataWriter;
+
 	@InjectMocks
 	FileService fileService;
 
-	@Test
+	static FileMetaData rootFolder;
+
+	@BeforeAll
+	static void init() {
+		rootFolder = FileMetaData.rootBuilder()
+			.id(1L)
+			.userId(1L)
+			.fileName("root")
+			.uploadName(".")
+			.fileType(FileType.FOLDER)
+			.build();
+	}
+
+	// @Test
 	void 파일이_없다면_실패한다() {
 		//given
 		var userId = 1L;
 		var folderId = 1L;
+		var file = mock(MultipartFile.class);
 
 		// when + then
 		assertThatThrownBy(() -> {
-			fileService.fileUpload(null, userId, folderId);
+			fileService.fileUpload(file, userId, folderId);
 		}).isInstanceOf(BusinessException.class)
 			.hasMessageContaining(ErrorCode.FILE_EMPTY.getMsg());
 	}
@@ -56,9 +78,9 @@ class FileServiceTest {
 		var folderId = 1L;
 		var file = mock(MultipartFile.class);
 
+		given(fileMetaDataReader.getRootFolder(anyLong())).willReturn(rootFolder);
 		given(file.getOriginalFilename()).willReturn("dd.jpg");
-		given(fileMetaDataRepository.existsByFileNameAndUserIdAndParent(anyString(), anyLong(), any()))
-			.willReturn(true);
+		given(fileMetaDataReader.isDuplicateFile(anyString(), anyLong(), any())).willReturn(true);
 
 		// when + then
 		assertThatThrownBy(() -> {
@@ -70,24 +92,26 @@ class FileServiceTest {
 	@Test
 	void 파일_메타데이터를_등록한다() {
 		// given
-		var fileId = 1L;
-		var folderId = 2L;
+		var fileId = 2L;
+		var folderId = rootFolder.getId();
 		var userId = 1L;
 		var file = mock(MultipartFile.class);
 		var originFileName = "dd.jpg";
+		var uploadFileName = "ddd.jpg";
 		var size = 1000L;
-		var contentType = "text/plain";
 		var fileMetaData = mock(FileMetaData.class);
 
 		given(file.getOriginalFilename()).willReturn(originFileName);
-		given(file.getSize()).willReturn(size);
-		given(file.getContentType()).willReturn(contentType);
 		given(fileMetaData.getId()).willReturn(fileId);
 		given(fileMetaData.getUserId()).willReturn(userId);
 		given(fileMetaData.getSize()).willReturn(size);
-		given(fileMetaData.getUploadName()).willReturn(originFileName);
+		given(fileMetaData.getUploadName()).willReturn(uploadFileName);
 
-		given(fileMetaDataRepository.save(any())).willReturn(fileMetaData);
+		given(fileMetaDataReader.getRootFolder(anyLong())).willReturn(rootFolder);
+		given(fileMetaDataWriter.saveFileMetaData(any(), anyLong(), anyString(), any())).willReturn(fileMetaData);
+		given(fileMetaDataReader.isDuplicateFile(anyString(), anyLong(), any())).willReturn(false);
+		given(pathService.createUniqueFileName(anyString())).willReturn(uploadFileName);
+		given(pathService.getFullFilePath(anyString(), anyString())).willReturn("C://");
 
 		// when
 		var response = fileService.fileUpload(file, userId, folderId);
@@ -96,18 +120,8 @@ class FileServiceTest {
 		assertThat(response)
 			.matches(metadata -> StringUtils.contains(metadata.uploadFileName(), originFileName))
 			.matches(metadata -> metadata.fileSize() == size)
+			.matches(metadata -> metadata.fileId() == fileId)
 			.matches(metadata -> metadata.userId() == userId);
-	}
-
-	@Test
-	void 저장된_파일이_아니라면_다운로드에_실패한다() {
-		var userId = 1L;
-		var fileId = 1L;
-
-		assertThatThrownBy(() -> {
-			fileService.fileDownLoad(userId, fileId);
-		}).isInstanceOf(BusinessException.class)
-			.hasMessageContaining(ErrorCode.FILE_NOT_FOUND.getMsg());
 	}
 
 	@Test
@@ -115,15 +129,10 @@ class FileServiceTest {
 		// given
 		var userId = 2L;
 		var fileId = 1L;
-		var fileMetaData = FileMetaData.fileBuilder()
-			.userId(1L)
-			.fileName("name.jpg")
-			.uploadName("name.jp")
-			.size(1000L)
-			.type(MediaType.IMAGE_JPEG.getType())
-			.build();
+		var fileMetaData = mock(FileMetaData.class);
 
-		given(fileMetaDataRepository.findById(anyLong())).willReturn(Optional.of(fileMetaData));
+		given(fileMetaData.getUserId()).willReturn(1L);
+		given(fileMetaDataReader.get(anyLong(), anyLong())).willReturn(fileMetaData);
 
 		// when + then
 		assertThatThrownBy(() -> {
@@ -137,16 +146,16 @@ class FileServiceTest {
 		// given
 		var userId = 1L;
 		var fileId = 1L;
+		var fileName = "name";
 		var resource = mock(UrlResource.class);
-		var fileMetaData = FileMetaData.fileBuilder()
-			.userId(1L)
-			.fileName("name.jpg")
-			.uploadName("name.jp")
-			.size(1000L)
-			.type(MediaType.IMAGE_JPEG.getType())
-			.build();
+		var fileMetaData = mock(FileMetaData.class);
 
-		given(fileMetaDataRepository.findById(anyLong())).willReturn(Optional.of(fileMetaData));
+		given(fileMetaData.getUserId()).willReturn(userId);
+		given(fileMetaData.getUploadName()).willReturn(fileName);
+
+		given(fileMetaDataReader.get(anyLong(), anyLong())).willReturn(fileMetaData);
+		given(fileMetaDataReader.getRootFolder(anyLong())).willReturn(rootFolder);
+		given(pathService.getFullFilePath(anyString(), anyString())).willReturn("C://");
 		given(fileUtil.downloadFile(anyString())).willReturn(resource);
 		given(resource.getContentAsByteArray()).willThrow(IOException.class);
 
@@ -165,20 +174,21 @@ class FileServiceTest {
 		var fileId = 1L;
 		var contentType = MediaType.IMAGE_JPEG.getType();
 		var fileName = "name.jpg";
-		var fileMetaData = FileMetaData.fileBuilder()
-			.userId(userId)
-			.fileName(fileName)
-			.uploadName(fileName)
-			.size(1000L)
-			.type(contentType)
-			.build();
+		var fileMetaData = mock(FileMetaData.class);
+
+		given(fileMetaData.getUserId()).willReturn(userId);
+		given(fileMetaData.getUploadName()).willReturn(fileName);
+		given(fileMetaData.getType()).willReturn(contentType);
+		given(fileMetaData.getUserId()).willReturn(userId);
+
+		given(fileMetaDataReader.get(anyLong(), anyLong())).willReturn(fileMetaData);
+		given(fileMetaDataReader.getRootFolder(anyLong())).willReturn(rootFolder);
+		given(pathService.getFullFilePath(anyString(), anyString())).willReturn("C://");
 
 		var byteArray = new byte[1];
 		var resource = mock(UrlResource.class);
 		lenient().when(resource.getFilename()).thenReturn(fileName);
 		lenient().when(resource.getContentAsByteArray()).thenReturn(byteArray);
-
-		given(fileMetaDataRepository.findById(anyLong())).willReturn(Optional.of(fileMetaData));
 		given(fileUtil.downloadFile(anyString())).willReturn(resource);
 
 		// when
@@ -191,30 +201,14 @@ class FileServiceTest {
 	}
 
 	@Test
-	void 저장된_파일이_아니라면_삭제에_실패한다() {
-		var userId = 1L;
-		var fileId = 1L;
-
-		assertThatThrownBy(() -> {
-			fileService.fileDelete(userId, fileId);
-		}).isInstanceOf(BusinessException.class)
-			.hasMessageContaining(ErrorCode.FILE_NOT_FOUND.getMsg());
-	}
-
-	@Test
 	void 본인이_업로드한_파일이_아니라면_삭제에_실패한다() {
 		// given
 		var userId = 2L;
 		var fileId = 1L;
-		var fileMetaData = FileMetaData.fileBuilder()
-			.userId(1L)
-			.fileName("name.jpg")
-			.uploadName("name.jp")
-			.size(1000L)
-			.type(MediaType.IMAGE_JPEG.getType())
-			.build();
+		var fileMetaData = mock(FileMetaData.class);
 
-		given(fileMetaDataRepository.findById(anyLong())).willReturn(Optional.of(fileMetaData));
+		given(fileMetaData.getUserId()).willReturn(1L);
+		given(fileMetaDataReader.get(anyLong(), anyLong())).willReturn(fileMetaData);
 
 		// when + then
 		assertThatThrownBy(() -> {
@@ -228,15 +222,12 @@ class FileServiceTest {
 		// given
 		var userId = 1L;
 		var fileId = 1L;
-		var fileMetaData = FileMetaData.fileBuilder()
-			.userId(userId)
-			.fileName("name.jpg")
-			.uploadName("name.jp")
-			.size(1000L)
-			.type(MediaType.IMAGE_JPEG.getType())
-			.build();
+		var uploadName = "file";
+		var fileMetaData = mock(FileMetaData.class);
 
-		given(fileMetaDataRepository.findById(anyLong())).willReturn(Optional.of(fileMetaData));
+		given(fileMetaData.getUserId()).willReturn(userId);
+		given(fileMetaData.getUploadName()).willReturn(uploadName);
+		given(fileMetaDataReader.get(anyLong(), anyLong())).willReturn(fileMetaData);
 
 		// when
 		fileService.fileDelete(userId, fileId);

--- a/src/test/java/com/c4cometrue/mystorage/service/FolderServiceTest.java
+++ b/src/test/java/com/c4cometrue/mystorage/service/FolderServiceTest.java
@@ -138,8 +138,11 @@ class FolderServiceTest {
 		given(folderReader.get(anyLong(), anyLong())).willReturn(folderMetaData);
 		given(folderReader.isDuplicateFile(anyString(), anyLong(), any())).willReturn(false);
 
-		// when + then
+		// when
 		folderService.renameFolder(userId, parentId, folderName);
+
+		// then
+		verify(folderMetaData, times(1)).rename(anyString());
 	}
 
 	@Test

--- a/src/test/java/com/c4cometrue/mystorage/service/FolderServiceTest.java
+++ b/src/test/java/com/c4cometrue/mystorage/service/FolderServiceTest.java
@@ -77,7 +77,7 @@ class FolderServiceTest {
 		assertThatThrownBy(() -> {
 			folderService.createFolder(userId, parentId, folderName);
 		}).isInstanceOf(BusinessException.class)
-			.hasMessageContaining(ErrorCode.INVALID_FOLDER.getMsg());
+			.hasMessageContaining(ErrorCode.INVALID_TYPE.getMsg());
 	}
 
 	@Test

--- a/src/test/java/com/c4cometrue/mystorage/service/FolderServiceTest.java
+++ b/src/test/java/com/c4cometrue/mystorage/service/FolderServiceTest.java
@@ -1,0 +1,184 @@
+package com.c4cometrue.mystorage.service;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+import java.util.Objects;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.c4cometrue.mystorage.common.exception.BusinessException;
+import com.c4cometrue.mystorage.common.exception.ErrorCode;
+import com.c4cometrue.mystorage.domain.FileMetaData;
+import com.c4cometrue.mystorage.domain.FileType;
+import com.c4cometrue.mystorage.repository.FileMetaDataReader;
+import com.c4cometrue.mystorage.repository.FileMetaDataWriter;
+import com.c4cometrue.mystorage.utils.FileUtil;
+
+@ExtendWith(MockitoExtension.class)
+class FolderServiceTest {
+
+	@Mock
+	PathService pathService;
+
+	@Mock
+	FileUtil fileUtil;
+
+	@Mock
+	FileMetaDataReader folderReader;
+
+	@Mock
+	FileMetaDataWriter folderWriter;
+
+	@InjectMocks
+	FolderService folderService;
+
+	@Test
+	void 루트_폴더_생성() {
+		// given
+		var userId = 1L;
+		var folderId = 1L;
+		var folderName = "user";
+		var fullPath = "C://user";
+		var folderMetaData = mock(FileMetaData.class);
+
+		given(folderMetaData.getId()).willReturn(folderId);
+		given(pathService.getFullFilePath(anyString(), anyString())).willReturn(fullPath);
+		given(folderReader.isDuplicateFile(anyString(), anyLong(), any())).willReturn(false);
+		given(folderWriter.saveFolderMetaData(anyLong(), anyString(), any())).willReturn(folderMetaData);
+
+		// when
+		var response = folderService.createRootFolder(userId, folderName);
+
+		// then
+		assertThat(response)
+			.matches(folder -> folder.id() == folderId);
+	}
+
+	@Test
+	void 부모가_폴더가_아니라면_에러가_발생한다() {
+		// given
+		var userId = 1L;
+		var parentId = 2L;
+		var folderName = "name";
+		var folderMetaData = mock(FileMetaData.class);
+
+		given(folderMetaData.getFileType()).willReturn(FileType.FILE);
+		given(folderReader.get(anyLong(), anyLong())).willReturn(folderMetaData);
+
+		// when + then
+		assertThatThrownBy(() -> {
+			folderService.createFolder(userId, parentId, folderName);
+		}).isInstanceOf(BusinessException.class)
+			.hasMessageContaining(ErrorCode.INVALID_FOLDER.getMsg());
+	}
+
+	@Test
+	void 저장하려는_폴더_이름이_중복된다면_에러가_발생한다() {
+		// given
+		var userId = 1L;
+		var parentId = 2L;
+		var folderName = "name";
+		var folderMetaData = mock(FileMetaData.class);
+
+		given(folderMetaData.getFileType()).willReturn(FileType.FOLDER);
+		given(folderReader.get(anyLong(), anyLong())).willReturn(folderMetaData);
+		given(folderReader.isDuplicateFile(anyString(), anyLong(), any())).willReturn(true);
+
+		// when + then
+		assertThatThrownBy(() -> {
+			folderService.createFolder(userId, parentId, folderName);
+		}).isInstanceOf(BusinessException.class)
+			.hasMessageContaining(ErrorCode.DUPLICATE_FOLDER.getMsg());
+	}
+
+	@Test
+	void 폴더를_생성한다() {
+		// given
+		var userId = 1L;
+		var folderId = 1L;
+		var parentId = 2L;
+		var folderName = "folder";
+		var folderMetaData = mock(FileMetaData.class);
+
+		given(folderMetaData.getId()).willReturn(folderId);
+		given(folderMetaData.getFileType()).willReturn(FileType.FOLDER);
+
+		given(folderReader.get(anyLong(), anyLong())).willReturn(folderMetaData);
+		given(folderReader.isDuplicateFile(anyString(), anyLong(), any())).willReturn(false);
+		given(folderWriter.saveFolderMetaData(anyLong(), anyString(), any())).willReturn(folderMetaData);
+
+		// when
+		var response = folderService.createFolder(userId, parentId, folderName);
+
+		// then
+		assertThat(response)
+			.matches(folder -> folder.id() == folderId);
+	}
+
+	@Test
+	void 폴더_이름_수정() {
+		// given
+		var userId = 1L;
+		var parentId = 2L;
+		var folderName = "folder";
+		var folderMetaData = mock(FileMetaData.class);
+		var parentMetaData = mock(FileMetaData.class);
+
+		given(folderMetaData.getFileType()).willReturn(FileType.FOLDER);
+		given(folderMetaData.getParent()).willReturn(parentMetaData);
+
+		given(folderReader.get(anyLong(), anyLong())).willReturn(folderMetaData);
+		given(folderReader.isDuplicateFile(anyString(), anyLong(), any())).willReturn(false);
+
+		// when + then
+		folderService.renameFolder(userId, parentId, folderName);
+	}
+
+	@Test
+	void 폴더_내용_조회() {
+		// given
+		var userId = 1L;
+		var folderId = 1L;
+		var fileId = 2L;
+		var fileName = "file";
+		var createdAt = LocalDateTime.now();
+		var fileSize = 1000L;
+		var folderMetaData = mock(FileMetaData.class);
+		var fileMetaData = mock(FileMetaData.class);
+		var files = List.of(fileMetaData, fileMetaData);
+
+		given(folderMetaData.getId()).willReturn(folderId);
+		given(folderMetaData.getFileName()).willReturn("folder");
+		given(folderMetaData.getFileType()).willReturn(FileType.FOLDER);
+
+		given(fileMetaData.getId()).willReturn(fileId);
+		given(fileMetaData.getFileType()).willReturn(FileType.FILE);
+		given(fileMetaData.getFileName()).willReturn(fileName);
+		given(fileMetaData.getCreatedAt()).willReturn(createdAt);
+		given(fileMetaData.getSize()).willReturn(fileSize);
+
+		given(folderReader.get(anyLong(), anyLong())).willReturn(folderMetaData);
+		given(folderReader.getFiles(anyLong(), any())).willReturn(files);
+
+		// when
+		var response = folderService.getFolderContents(userId, folderId);
+
+		// then
+		assertThat(response)
+			.matches(folder -> folder.folderId() == folderId)
+			.matches(folder -> folder.subFileList().get(0).fileId() == fileId)
+			.matches(folder -> Objects.equals(folder.subFileList().get(0).fileName(), fileName))
+			.matches(folder -> Objects.equals(folder.subFileList().get(0).createdAt(),
+				DateTimeFormatter.ISO_LOCAL_DATE_TIME.format(createdAt)))
+			.matches(folder -> folder.subFileList().get(0).fileSize() == fileSize);
+
+	}
+}

--- a/src/test/java/com/c4cometrue/mystorage/service/PathServiceTest.java
+++ b/src/test/java/com/c4cometrue/mystorage/service/PathServiceTest.java
@@ -1,0 +1,51 @@
+package com.c4cometrue.mystorage.service;
+
+import static org.assertj.core.api.Assertions.*;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+class PathServiceTest {
+
+	PathService pathService;
+
+	String baseDir = "C://root/";
+
+	@BeforeEach
+	public void setUp() {
+		pathService = new PathService();
+		ReflectionTestUtils.setField(pathService,
+			"baseDir",
+			baseDir);
+	}
+
+	@Test
+	void 루트_폴더의_물리적인_경로를_반환한다() {
+		// given
+		var parentDir = "";
+		var fileName = "name";
+
+		// when
+		var response = pathService.getFullFilePath(parentDir, fileName);
+
+		// then
+		assertThat(response)
+			.matches(path -> path.equals(baseDir + fileName));
+	}
+
+	@Test
+	void 파일의_물리적인_경로를_반환한다() {
+		// given
+		var parentDir = "/test";
+		var fileName = " name ";
+
+		// when
+		var response = pathService.getFullFilePath(parentDir, fileName);
+
+		// then
+		assertThat(response)
+			.matches(path -> path.equals(baseDir + "/test/name"));
+
+	}
+}

--- a/src/test/java/com/c4cometrue/mystorage/service/PathServiceTest.java
+++ b/src/test/java/com/c4cometrue/mystorage/service/PathServiceTest.java
@@ -45,7 +45,7 @@ class PathServiceTest {
 
 		// then
 		assertThat(response)
-			.matches(path -> path.equals(baseDir + "/test/name"));
+			.matches(path -> path.equals(baseDir + "/test/ name"));
 
 	}
 }

--- a/src/test/java/com/c4cometrue/mystorage/utils/FileUtilTest.java
+++ b/src/test/java/com/c4cometrue/mystorage/utils/FileUtilTest.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.BDDMockito.*;
 
 import java.io.IOException;
+import java.nio.file.FileAlreadyExistsException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 
@@ -142,6 +143,32 @@ class FileUtilTest {
 
 		// then
 		assertEquals(ErrorCode.FILE_DELETE_FAILED, ex.getErrorCode());
+	}
+
+	@Test
+	void 폴더_생성_과정에서_이미_존재한다면_생성이_실패한다() {
+		// given
+		fileMockedStatic.when(() -> Files.createDirectory(any())).thenThrow(FileAlreadyExistsException.class);
+
+		// when
+		var ex = assertThrows(BusinessException.class,
+			() -> fileUtil.createFolder(fileUploadPath));
+
+		// then
+		assertEquals(ErrorCode.DUPLICATE_FOLDER, ex.getErrorCode());
+	}
+
+	@Test
+	void 폴더_생성_과정에서_문제가_발생하면_생성이_실패한다() {
+		// given
+		fileMockedStatic.when(() -> Files.createDirectory(any())).thenThrow(IOException.class);
+
+		// when
+		var ex = assertThrows(BusinessException.class,
+			() -> fileUtil.createFolder(fileUploadPath));
+
+		// then
+		assertEquals(ErrorCode.FOLDER_CREATE_FAILED, ex.getErrorCode());
 	}
 
 }


### PR DESCRIPTION
[FileMetaData]

- 폴더도 하나의 파일이기 때문에 굳이 파일과 폴더 테이블을 분리하지 않고, `FileType` 칼럼을 통해서 동일 테이블 내에서 구분해줬습니다. 
  + 폴더의 `uploadName` 에는 `.` 를 저장하도록 했습니다. 해당 필드를 통해 파일/폴더를 구분할 수 있지만, `enum` 이 명시적으로 더 잘 구분되는 것 같아서 생성했습니다.
- 처음에는 `folderPath` 라는 필드를 두어 현재 파일/폴더가 속해있는 부모 폴더의 논리적인 경로를 저장했지만, 굳이 파일 서버에 계층 구조를 유지할게 아니라면 아래와 같은 이유로 경로를 추적하지 않는게 낫다고 판단했습니다.
    + 파일의 논리적인 경로를 추적하면 폴더 이름 수정, 폴더 이동 시 재귀적으로 하위에 있는 모든 파일 및 폴더의 경로 또한 변경해줘야 하므로 큰 부하가 걸립니다.
    + 파일 정보를 보여주는 API에서 파일의 논리적인 경로가 필요하지만, 요청 자체가 많지 않을 것 같고 요청이 오더라도 재귀적으로 위로 올라가는 방향이기 때문에 밑으로 타고 내려가는 비용보다 적을 것 같다 판단했습니다. (혹은 프론트에서 처리)
    + 예를 들어 현재 파일이 깊이 10 위치에 저장되어 있고, 뒤에 만개의 파일이 존재한다 했을 때 해당 폴더 이름 변경 시 만개의 파일의 경로 모두를 수정해줘야 하지만 논리적인 경로만 가져온다면 위로 10번만 올라가면 되기 때문입니다. (근데 지금 생각해보니 `bulkupdate` 하면 부하를 좀 줄일 수 있겠네요.)
    
[FolderService]

- 각 사용자에 해당하는 루트 폴더를 하나씩 만들어주었습니다.
    - 파일과 마찬가지로, 물리적인 폴더 저장이나 DB 메타데이터 저장이 실패해 롤백되는 상황을 고려해 1. 중복 검사 2. 메타데이터 저장 3. 물리적인 폴더 저장 순으로 구현했습니다.
    - 루트 폴더 생성할 때 `parent` 에 `null` 값이 들어가는데 혹시나 문제될게 있을지 고민됩니다.
- 루트 폴더를 생성한 이후에는, 계층 구조로 보여주는 것은 프론트의 몫이라고 생각해 굳이 물리적인 서브 폴더를 생성하지 않도록 했습니다.
    - 실제 파일 서버에 계층 구조를 유지하면 파일 I/O 로 인한 부하가 클 것이라 생각했습니다.
- 파일의 논리적인 경로가 있었다면 변경하려는 폴더 아래에 있는 모든 자식들의 경로도 변경이 필요했겠지만, 없앰에 따라 자식들은 제외하고 변경하려는 폴더 자체만 이름 수정하도록 했습니다.

[FileMetaDataReader, FileMetaDataWriter]

- 엔티티를 생성하고 저장하는 로직이 중복되어 데이터베이스 CRUD 로직을 따로 분리했습니다.
- 메서드를 따로 추출하고 내부에 다시 빌더를 쓰는게 좀 요상한것 같기도 하네요.

[FileService]

- 파일은 모두 사용자 별 루트 폴더 내부에 저장되어야 하도록 수정했습니다.
- 폴더가 생김에 따라, 파일 중복 여부를 검사할 때 같은 폴더 아래에 파일이 존재하는지 확인하도록 수정했습니다.